### PR TITLE
Fix typo in comment re: unixtime support

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 #ifndef __config_h_
 #define __config_h_
 
-// comment this out if you need unixtime support
+// uncomment this if you need unixtime support
 // this will add about 380bytes to your firmware
 //#define CONFIG_UNIXTIME
 


### PR DESCRIPTION
comment this out -> uncomment this